### PR TITLE
Feat: Implement preloading of dataset images to CPU RAM

### DIFF
--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -7,48 +7,43 @@
 #include <vector>               // For std::vector
 #include <torch/torch.h>        // For torch::Tensor, torch::stack, etc.
 
-namespace gs { // Assuming classes are in namespace gs based on other files
-
 // Implementation of try_preload_images_to_cpu
-void CameraDataset::try_preload_images_to_cpu(const gs::param::OptimizationParameters& optim_params, const std::string& dataset_name) {
+// Fully qualify the class and namespace for the method definition.
+void gs::CameraDataset::try_preload_images_to_cpu(const gs::param::OptimizationParameters& optim_params, const std::string& dataset_name) {
     if (!optim_params.preload_images_to_cpu) {
         return;
     }
 
-    std::cout << "[" << dataset_name << " dataset] Starting preloading of " << _indices.size() << " images to CPU RAM..." << std::endl;
+    std::cout << "[" << dataset_name << " dataset] Starting preloading of " << this->_indices.size() << " images to CPU RAM..." << std::endl;
     auto start_time = std::chrono::high_resolution_clock::now();
 
     std::vector<torch::Tensor> image_list_for_stacking;
-    image_list_for_stacking.reserve(_indices.size());
+    image_list_for_stacking.reserve(this->_indices.size());
 
-    for (size_t i = 0; i < _indices.size(); ++i) {
-        size_t original_camera_idx = _indices[i];
-        // Ensure we use .get() if _cameras stores shared_ptr, or directly if it's Camera objects.
-        // Based on declaration `std::vector<std::shared_ptr<Camera>> _cameras;`, .get() is needed.
-        Camera* cam = _cameras[original_camera_idx].get();
-        torch::Tensor img_tensor = cam->load_and_get_image(_datasetConfig.resolution);
+    for (size_t i = 0; i < this->_indices.size(); ++i) {
+        size_t original_camera_idx = this->_indices[i];
+        Camera* cam = this->_cameras[original_camera_idx].get();
+        torch::Tensor img_tensor = cam->load_and_get_image(this->_datasetConfig.resolution);
         img_tensor = img_tensor.to(torch::kCPU).contiguous(); // Ensure on CPU
         image_list_for_stacking.push_back(img_tensor);
 
-        if ((i + 1) % 100 == 0 || (i + 1) == _indices.size()) {
-            std::cout << "[" << dataset_name << " dataset] Preloaded " << (i + 1) << "/" << _indices.size() << " images to CPU..." << std::endl;
+        if ((i + 1) % 100 == 0 || (i + 1) == this->_indices.size()) {
+            std::cout << "[" << dataset_name << " dataset] Preloaded " << (i + 1) << "/" << this->_indices.size() << " images to CPU..." << std::endl;
         }
     }
 
     if (!image_list_for_stacking.empty()) {
-        preloaded_cpu_image_data_ = torch::stack(image_list_for_stacking, 0).contiguous();
+        this->preloaded_cpu_image_data_ = torch::stack(image_list_for_stacking, 0).contiguous();
         auto end_time = std::chrono::high_resolution_clock::now();
         auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
 
-        float total_size_mb = (preloaded_cpu_image_data_.value().nbytes() / (1024.0f * 1024.0f));
+        float total_size_mb = (this->preloaded_cpu_image_data_.value().nbytes() / (1024.0f * 1024.0f));
 
-        std::cout << "[" << dataset_name << " dataset] Finished preloading " << _indices.size() << " images to CPU RAM." << std::endl;
-        std::cout << "  Preloaded tensor shape: " << preloaded_cpu_image_data_.value().sizes() << std::endl;
+        std::cout << "[" << dataset_name << " dataset] Finished preloading " << this->_indices.size() << " images to CPU RAM." << std::endl;
+        std::cout << "  Preloaded tensor shape: " << this->preloaded_cpu_image_data_.value().sizes() << std::endl;
         std::cout << "  Estimated size: " << std::fixed << std::setprecision(2) << total_size_mb << " MB" << std::endl;
         std::cout << "  Preloading time: " << duration.count() << " ms" << std::endl;
     } else {
         std::cout << "[" << dataset_name << " dataset] No images to preload." << std::endl;
     }
 }
-
-} // namespace gs


### PR DESCRIPTION
This commit introduces a feature to preload all images for a dataset split (train/validation) into a single contiguous tensor in CPU RAM at the start of training. This can significantly improve performance by reducing disk I/O and on-the-fly image decoding during training loops.

Key changes:
- Added a boolean configuration parameter `preload_images_to_cpu` (default: false) to `optimization_params.json` and updated C++ parameter handling.
- Modified `CameraDataset`:
    - Added an optional `torch::Tensor preloaded_cpu_image_data_` to store the stacked images.
    - Implemented a new method `try_preload_images_to_cpu` which:
        - If enabled by the config, iterates through its assigned images.
        - Loads each image, ensures it's on CPU, and collects it. - Stacks all collected images into `preloaded_cpu_image_data_`. - Includes logging for the preloading process.
    - Updated the `get()` method to serve images from `preloaded_cpu_image_data_` if available, otherwise, it loads images on demand as before.
- The implementation of `try_preload_images_to_cpu` has been moved to `src/dataset.cpp`. (Note: `CMakeLists.txt` will need to be updated by the user to include this new source file).
- The `Trainer` constructor now calls `try_preload_images_to_cpu` for the training and validation datasets after their creation.
- Applied a fix to `src/dataset.cpp` for a potential E0551 scope error by fully qualifying the `try_preload_images_to_cpu` method definition and using `this->` for member access.