### PR TITLE
Fix build errors related to Eigen and OptimizationParameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(CUDAToolkit REQUIRED)
 find_package(TBB REQUIRED)
 find_package(Threads REQUIRED)
 find_package(OpenGL REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 # Python packages - Use modern Python3 finding
 find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
@@ -99,6 +100,7 @@ target_include_directories(gaussian_host
         ${CMAKE_CURRENT_SOURCE_DIR}/gsplat  # Add gsplat headers
         ${CUDAToolkit_INCLUDE_DIRS}         # Add CUDA headers for interop
         ${CMAKE_CURRENT_SOURCE_DIR}         # For accessing kernels/newton_kernels.cuh
+        ${EIGEN3_INCLUDE_DIRS}              # Add Eigen includes
         PRIVATE
         ${Python3_INCLUDE_DIRS}
         ${OPENGL_INCLUDE_DIRS}
@@ -116,6 +118,7 @@ target_link_libraries(gaussian_host
         args
         Python3::Python
         gsplat_backend  # Link to gsplat
+        Eigen3::Eigen   # Link to Eigen
         ${OPENGL_LIBRARIES}
         CUDA::cudart    # Add CUDA runtime for interop
 )

--- a/src/setup_utils.cpp
+++ b/src/setup_utils.cpp
@@ -22,9 +22,9 @@ void setup_camera_knn_for_splat_data(
     std::cout << "INFO: Setting up camera KNN data..." << std::endl;
 
     // 1. Get K_neighbors from optimization parameters
-    const int K_neighbors = opt_params.k_nearest_neighbors_for_cameras;
+    const int K_neighbors = opt_params.newton_knn_k;
     if (K_neighbors <= 0) {
-        std::cout << "K_neighbors is " << K_neighbors << ". Skipping camera KNN calculation." << std::endl;
+        std::cout << "K_neighbors (opt_params.newton_knn_k) is " << K_neighbors << ". Skipping camera KNN calculation." << std::endl;
         // Ensure KNN list is empty or appropriately sized if K=0
         splat_data.set_camera_knns({}); // Set to empty KNNs
         return;


### PR DESCRIPTION
- Added Eigen3 to CMakeLists.txt for the gaussian_host library.
- Corrected usage of optimization parameter in setup_utils.cpp from 'k_nearest_neighbors_for_cameras' to 'newton_knn_k'.

These changes address multiple compilation and linker errors, including missing Eigen headers and unresolved external symbols.