### PR TITLE
Refactor: Remove Eigen dependency and use torch::Tensor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ find_package(CUDAToolkit REQUIRED)
 find_package(TBB REQUIRED)
 find_package(Threads REQUIRED)
 find_package(OpenGL REQUIRED)
-find_package(Eigen3 REQUIRED)
 
 # Python packages - Use modern Python3 finding
 find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
@@ -100,7 +99,6 @@ target_include_directories(gaussian_host
         ${CMAKE_CURRENT_SOURCE_DIR}/gsplat  # Add gsplat headers
         ${CUDAToolkit_INCLUDE_DIRS}         # Add CUDA headers for interop
         ${CMAKE_CURRENT_SOURCE_DIR}         # For accessing kernels/newton_kernels.cuh
-        ${EIGEN3_INCLUDE_DIRS}              # Add Eigen includes
         PRIVATE
         ${Python3_INCLUDE_DIRS}
         ${OPENGL_INCLUDE_DIRS}
@@ -118,7 +116,6 @@ target_link_libraries(gaussian_host
         args
         Python3::Python
         gsplat_backend  # Link to gsplat
-        Eigen3::Eigen   # Link to Eigen
         ${OPENGL_LIBRARIES}
         CUDA::cudart    # Add CUDA runtime for interop
 )

--- a/include/core/newton_strategy.hpp
+++ b/include/core/newton_strategy.hpp
@@ -7,7 +7,7 @@
 #include "core/dataset.hpp" // For CameraDataset, Camera
 #include "core/rasterizer.hpp"   // For gs::RenderOutput
 
-#include <Eigen/Dense>
+#include <torch/torch.h> // For torch::Tensor
 #include <vector>
 #include <string>
 #include <memory> // For std::unique_ptr
@@ -69,9 +69,9 @@ private:
     std::shared_ptr<CameraDataset> train_dataset_ref_; // For accessing all camera poses and loading GTs
     std::vector<const Camera*> all_train_cameras_cache_; // Cache of camera pointers from train_dataset_ref_
 
-    Eigen::Vector3f scene_center_for_knn_;
+    torch::Tensor scene_center_for_knn_; // Expected to be a {3} float tensor
     float scene_radius_for_knn_;
-    std::vector<Eigen::Vector3f> projected_camera_positions_on_sphere_;
+    std::vector<torch::Tensor> projected_camera_positions_on_sphere_; // Each element a {3} float tensor
     std::vector<std::pair<const Camera*, torch::Tensor>> current_knn_targets_gpu_; // GT images on GPU
 
     void initialize_knn_data_if_needed();


### PR DESCRIPTION
- Removed Eigen3 dependency from CMakeLists.txt and newton_strategy.hpp.
- Updated newton_strategy.hpp and newton_strategy.cpp to use torch::Tensor for 3D vector operations previously handled by Eigen::Vector3f.
- This affects KNN-related calculations such as scene center estimation, camera position projection, and spherical distance computation.
- The fix for the OptimizationParameters member name in setup_utils.cpp (newton_knn_k) is maintained.