### PR TITLE
Fix(newton): Apply .contiguous() to t_wc in cam_pos calculation

### DIFF
--- a/include/core/newton_optimizer.hpp
+++ b/include/core/newton_optimizer.hpp
@@ -34,6 +34,7 @@ public:
 
         // For L2 loss part in Hessian computation (as per paper)
         bool use_l2_for_hessian_L_term = true;
+        bool debug_print_shapes = false;         // Enable debug prints for tensor shapes
     };
 
     NewtonOptimizer(SplatData& splat_data,


### PR DESCRIPTION
Adds .contiguous() to the t_wc tensor before the matmul operation used to calculate camera position. This is a speculative fix for a baddbmm error that might be caused by non-contiguous strides of t_wc confusing PyTorch's bmm meta function.

Also adds debug print statements for tensor shapes/strides controlled by a new 'debug_print_shapes' option in NewtonOptimizer::Options.