### PR TITLE
Fix(newton): Add scalar_type debug prints for dtype mismatch error

### DIFF
--- a/src/newton_optimizer.cpp
+++ b/src/newton_optimizer.cpp
@@ -79,6 +79,24 @@ NewtonOptimizer::PositionHessianOutput NewtonOptimizer::compute_position_hessian
         std::cout << "[DEBUG] compute_pos_hess: t_wc.contiguous() shape: " << t_wc.contiguous().sizes()
                   << " strides: " << t_wc.contiguous().strides()
                   << " contiguous: " << t_wc.contiguous().is_contiguous() << std::endl;
+
+        // Dtype checks
+        std::cout << "[DEBUG] DTYPE_CHECK model_snapshot.get_means(): " << model_snapshot.get_means().scalar_type() << std::endl;
+        std::cout << "[DEBUG] DTYPE_CHECK model_snapshot.get_scaling(): " << model_snapshot.get_scaling().scalar_type() << std::endl;
+        std::cout << "[DEBUG] DTYPE_CHECK model_snapshot.get_rotation(): " << model_snapshot.get_rotation().scalar_type() << std::endl;
+        std::cout << "[DEBUG] DTYPE_CHECK model_snapshot.get_opacity(): " << model_snapshot.get_opacity().scalar_type() << std::endl;
+        std::cout << "[DEBUG] DTYPE_CHECK model_snapshot.get_shs(): " << model_snapshot.get_shs().scalar_type() << std::endl;
+        std::cout << "[DEBUG] DTYPE_CHECK view_mat_tensor: " << view_mat_tensor.scalar_type() << std::endl;
+        std::cout << "[DEBUG] DTYPE_CHECK K_matrix: " << K_matrix.scalar_type() << std::endl;
+        // cam_pos_tensor is defined after this block, will check before passing to kernel launcher
+        if (render_output.means2d.defined()) std::cout << "[DEBUG] DTYPE_CHECK render_output.means2d: " << render_output.means2d.scalar_type() << std::endl; else std::cout << "[DEBUG] DTYPE_CHECK render_output.means2d: UNDEFINED" << std::endl;
+        if (render_output.depths.defined()) std::cout << "[DEBUG] DTYPE_CHECK render_output.depths: " << render_output.depths.scalar_type() << std::endl; else std::cout << "[DEBUG] DTYPE_CHECK render_output.depths: UNDEFINED" << std::endl;
+        if (render_output.radii.defined()) std::cout << "[DEBUG] DTYPE_CHECK render_output.radii: " << render_output.radii.scalar_type() << std::endl; else std::cout << "[DEBUG] DTYPE_CHECK render_output.radii: UNDEFINED" << std::endl;
+        if (loss_derivs.dL_dc.defined()) std::cout << "[DEBUG] DTYPE_CHECK loss_derivs.dL_dc: " << loss_derivs.dL_dc.scalar_type() << std::endl; else std::cout << "[DEBUG] DTYPE_CHECK loss_derivs.dL_dc: UNDEFINED" << std::endl;
+        if (loss_derivs.d2L_dc2_diag.defined()) std::cout << "[DEBUG] DTYPE_CHECK loss_derivs.d2L_dc2_diag: " << loss_derivs.d2L_dc2_diag.scalar_type() << std::endl; else std::cout << "[DEBUG] DTYPE_CHECK loss_derivs.d2L_dc2_diag: UNDEFINED" << std::endl;
+        std::cout << "[DEBUG] DTYPE_CHECK H_p_output_packed: " << H_p_output_packed.scalar_type() << std::endl;
+        std::cout << "[DEBUG] DTYPE_CHECK grad_p_output: " << grad_p_output.scalar_type() << std::endl;
+        // visibility_mask_for_model is bool, not checked for float
     }
 
     // Transpose the inner two dimensions for matrix transpose, robust to batches.
@@ -92,6 +110,10 @@ NewtonOptimizer::PositionHessianOutput NewtonOptimizer::compute_position_hessian
     // For now, we pass what we have. The kernel must be robust.
     // `render_output.visibility_indices` could be a map from render_output's internal indexing to original model indices.
     // `render_output.visibility_filter` could be a boolean mask on the *culled* set from rasterizer.
+
+    if (options_.debug_print_shapes) {
+        std::cout << "[DEBUG] DTYPE_CHECK cam_pos_tensor: " << cam_pos_tensor.scalar_type() << std::endl;
+    }
 
     NewtonKernels::compute_position_hessian_components_kernel_launcher(
         render_output.height, render_output.width, render_output.image.size(-1), // Image: H, W, C


### PR DESCRIPTION
Adds std::cout statements to print the scalar_type() for all relevant tensors within NewtonOptimizer::compute_position_hessian_components_cuda before their data pointers are accessed as float*.

This is to help diagnose an error: "expected scalar type Float but found Int" (or Bool), by identifying which tensor has the incorrect data type.