### PR TITLE
Fix(newton): Use direct visibility mask and enhance debug prints

### DIFF
--- a/src/newton_optimizer.cpp
+++ b/src/newton_optimizer.cpp
@@ -328,8 +328,18 @@ void NewtonOptimizer::step(int iteration,
     torch::Tensor visible_indices = torch::where(visibility_mask_for_model)[0];
     int num_visible_gaussians_in_model = visible_indices.size(0);
 
+    if (options_.debug_print_shapes) {
+        std::cout << "[NewtonOpt] Step - Iteration: " << iteration
+                  << ", num_visible_gaussians_in_model (from mask): " << num_visible_gaussians_in_model
+                  << ", visibility_mask_for_model sum: " << visibility_mask_for_model.sum().item<long>()
+                  << std::endl;
+    }
+
     if (num_visible_gaussians_in_model == 0) {
-        return;
+        if (options_.debug_print_shapes) {
+             std::cout << "[NewtonOpt] Step: No visible Gaussians based on mask at iteration " << iteration << ". Skipping Newton update." << std::endl;
+        }
+        return; // Early exit
     }
 
     torch::Tensor means_visible_from_model = model_.means().detach().index_select(0, visible_indices);


### PR DESCRIPTION
- Updates `NewtonStrategy::compute_visibility_mask_for_model` to directly use `render_output.visibility`. This assumes `render_output.visibility` is a boolean mask of shape [P_total] (total Gaussians), indicating Gaussians with a projected radius > 0, as determined during rasterizer analysis. Includes TORCH_CHECKs for shape and dtype.
- Adds debug prints to `NewtonOptimizer::step` to output the iteration number, the number of visible Gaussians based on the mask, and the sum of the mask. Also prints a message if the Newton update is skipped due to zero visible Gaussians. These prints are conditional on `options_.debug_print_shapes`.