### PR TITLE
Fix(newton): Change item<long> to item<int64_t> in debug print

### DIFF
--- a/src/newton_optimizer.cpp
+++ b/src/newton_optimizer.cpp
@@ -329,9 +329,11 @@ void NewtonOptimizer::step(int iteration,
     int num_visible_gaussians_in_model = visible_indices.size(0);
 
     if (options_.debug_print_shapes) {
+        torch::Tensor visibility_sum_tensor = visibility_mask_for_model.sum();
+        long visibility_sum = visibility_sum_tensor.defined() ? visibility_sum_tensor.item<int64_t>() : -1L;
         std::cout << "[NewtonOpt] Step - Iteration: " << iteration
                   << ", num_visible_gaussians_in_model (from mask): " << num_visible_gaussians_in_model
-                  << ", visibility_mask_for_model sum: " << visibility_mask_for_model.sum().item<long>()
+                  << ", visibility_mask_for_model sum: " << visibility_sum
                   << std::endl;
     }
 


### PR DESCRIPTION
Changes the debug print in `NewtonOptimizer::step` to use `visibility_mask_for_model.sum().item<int64_t>()` instead of `item<long>()`.

This is a workaround for a linker error LNK2019 indicating that `at::Tensor::item<long>()` was an unresolved external symbol. Using `item<int64_t>()` is more standard for tensor sums and more likely to have its implementation readily available in linked PyTorch libraries.